### PR TITLE
autoreconf to generate ./configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,6 @@ $ sudo yum install pango-devel cairo-devel tokyocabinet-devel
 Duc use the GNU Autoconf system for compiling if you do not have a
 pre-built package.  So you can normally just do:
 
-```
-$ ./configure
-$ make
-$ sudo make install
-$ sudo ldconfig
-```
-
-to install duc into /usr/local/bin. 
-
-If you need to edit the source, you will need to have the GNU autoconf
-and libtool installed first, which you can do with:
 
 Ubuntu/Debian:  
 
@@ -74,8 +63,16 @@ Then you will need to do:
 $ autoreconf --install
 ```
 
-to generate the correct files.  Once that is done, you can do the
-above configure, make and make install steps.
+
+```
+$ ./configure
+$ make
+$ sudo make install
+$ sudo ldconfig
+```
+
+to install duc into /usr/local/bin. 
+
 
 
 ### Usage


### PR DESCRIPTION
The Git Repo doesn't contain ./configure, so you need to build it using autoreconf first