### PR TITLE
2 patches for limiting indexing depth and hiding file names

### DIFF
--- a/duc/index.c
+++ b/duc/index.c
@@ -19,6 +19,7 @@
 static struct option longopts[] = {
 	{ "compress",        no_argument,       NULL, 'c' },
 	{ "database",        required_argument, NULL, 'd' },
+	{ "maxdepth",        required_argument, NULL, 'm' },
 	{ "force",           no_argument,       NULL, 'f' },
 	{ "one-file-system", required_argument, NULL, 'x' },
 	{ "quiet",           no_argument,       NULL, 'q' },
@@ -30,6 +31,7 @@ static struct option longopts[] = {
 static int index_main(int argc, char **argv)
 {
 	int c;
+	int maxdepth = 999999;
 	char *path_db = NULL;
 	duc_index_flags index_flags = 0;
 	int open_flags = DUC_OPEN_RW | DUC_OPEN_COMPRESS;
@@ -43,7 +45,7 @@ static int index_main(int argc, char **argv)
 		
 	duc_index_req *req = duc_index_req_new(duc);
 
-	while( ( c = getopt_long(argc, argv, "d:e:fqxuv", longopts, NULL)) != EOF) {
+	while( ( c = getopt_long(argc, argv, "d:e:m:fqxuv", longopts, NULL)) != EOF) {
 
 		switch(c) {
 			case 'd':
@@ -66,6 +68,9 @@ static int index_main(int argc, char **argv)
 				break;
 			case 'x':
 				index_flags |= DUC_INDEX_XDEV;
+				break;
+			case 'm':
+				maxdepth = atoi(optarg)+1;
 				break;
 			default:
 				return -2;
@@ -94,7 +99,7 @@ static int index_main(int argc, char **argv)
 	for(i=0; i<argc; i++) {
 
 		struct duc_index_report *report;
-		report = duc_index(req, argv[i], index_flags);
+		report = duc_index(req, argv[i], index_flags, maxdepth);
 		if(report == NULL) {
 			fprintf(stderr, "%s\n", duc_strerror(duc));
 			continue;
@@ -137,6 +142,7 @@ struct cmd cmd_index = {
 		"  -u, --uncompressed      do not use compression for database\n"
 		"  -v, --verbose           verbose mode, can be passed two times for debugging\n"
 		"  -x, --one-file-system   don't cross filesystem boundaries\n"
+		"  -m, --maxdepth=ARG      limit directory names to given depth\n"
 		,
 	.main = index_main
 };

--- a/duc/index.c
+++ b/duc/index.c
@@ -20,6 +20,7 @@ static struct option longopts[] = {
 	{ "compress",        no_argument,       NULL, 'c' },
 	{ "database",        required_argument, NULL, 'd' },
 	{ "maxdepth",        required_argument, NULL, 'm' },
+	{ "hidefiles",       no_argument,       NULL, 'h' },
 	{ "force",           no_argument,       NULL, 'f' },
 	{ "one-file-system", required_argument, NULL, 'x' },
 	{ "quiet",           no_argument,       NULL, 'q' },
@@ -45,7 +46,7 @@ static int index_main(int argc, char **argv)
 		
 	duc_index_req *req = duc_index_req_new(duc);
 
-	while( ( c = getopt_long(argc, argv, "d:e:m:fqxuv", longopts, NULL)) != EOF) {
+	while( ( c = getopt_long(argc, argv, "d:e:m:hfqxuv", longopts, NULL)) != EOF) {
 
 		switch(c) {
 			case 'd':
@@ -71,6 +72,9 @@ static int index_main(int argc, char **argv)
 				break;
 			case 'm':
 				maxdepth = atoi(optarg)+1;
+				break;
+			case 'h':
+				index_flags |= DUC_INDEX_HIDE;
 				break;
 			default:
 				return -2;
@@ -143,6 +147,7 @@ struct cmd cmd_index = {
 		"  -v, --verbose           verbose mode, can be passed two times for debugging\n"
 		"  -x, --one-file-system   don't cross filesystem boundaries\n"
 		"  -m, --maxdepth=ARG      limit directory names to given depth\n"
+		"  -h, --hidefiles         hide file names\n"
 		,
 	.main = index_main
 };

--- a/lib/duc.h
+++ b/lib/duc.h
@@ -111,7 +111,7 @@ int duc_close(duc *duc);
 
 duc_index_req *duc_index_req_new(duc *duc);
 int duc_index_req_add_exclude(duc_index_req *req, const char *pattern);
-struct duc_index_report *duc_index(duc_index_req *req, const char *path, duc_index_flags flags);
+struct duc_index_report *duc_index(duc_index_req *req, const char *path, duc_index_flags flags, int maxdepth);
 int duc_index_req_free(duc_index_req *req);
 int duc_index_report_free(struct duc_index_report *rep);
 

--- a/lib/duc.h
+++ b/lib/duc.h
@@ -23,6 +23,7 @@ typedef enum {
 
 typedef enum {
 	DUC_INDEX_XDEV	= 1<<0,    /* Do not cross device boundaries while indexing */
+	DUC_INDEX_HIDE	= 1<<1,    /* Hide file names */
 } duc_index_flags;
 
 

--- a/lib/index.c
+++ b/lib/index.c
@@ -180,7 +180,11 @@ static off_t index_dir(struct duc_index_req *req, struct duc_index_report *repor
 		/* Store record */
 
 		if (depth > 0) {		/* cut entries at given depth */
-			duc_dir_add_ent(dir, e->d_name, size, mode_t_to_duc_mode(st.st_mode), st.st_dev, st.st_ino);
+			if ((req->flags & DUC_INDEX_HIDE) && !S_ISDIR(st.st_mode)) {	/* hide file names if necessary */
+				duc_dir_add_ent(dir, "<FILES>", size, mode_t_to_duc_mode(st.st_mode), st.st_dev, st.st_ino);
+			} else {
+				duc_dir_add_ent(dir, e->d_name, size, mode_t_to_duc_mode(st.st_mode), st.st_dev, st.st_ino);
+			}
 		}
 		dir->size_total += size;
 		size_dir += size;


### PR DESCRIPTION
@zevv    hey Ico,

first off: thanks for this nice philesight rewrite! I have just ported our philesight patches to DUC. Background: we create monthly usage graphs on hundreds of TiB of research data. The sheer amount of data required us to add two options:

- limit indexing depth to a given level in order to keep DB size reasonable
- hide file names due to privacy reasons. Only directory names are shown

If you think these changes could be useful upstream, please feel free to pull them.

thanks,
-Christian