### PR TITLE
Do not store device id and inode for regular files

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -50,8 +50,10 @@ duc_errno db_write_dir(struct duc_dir *dir)
 		buffer_put_string(b, ent->name);
 		buffer_put_varint(b, ent->size);
 		buffer_put_varint(b, ent->mode);
-		buffer_put_varint(b, ent->dev);
-		buffer_put_varint(b, ent->ino);
+		if(ent->mode == DUC_MODE_DIR) {
+			buffer_put_varint(b, ent->dev);
+			buffer_put_varint(b, ent->ino);
+		}
 		ent++;
 	}
 
@@ -109,8 +111,10 @@ struct duc_dir *db_read_dir(struct duc *duc, dev_t dev, ino_t ino)
 		buffer_get_string(b, &name);
 		buffer_get_varint(b, &size);
 		buffer_get_varint(b, &mode);
-		buffer_get_varint(b, &dev);
-		buffer_get_varint(b, &ino);
+		if(mode == DUC_MODE_DIR) {
+			buffer_get_varint(b, &dev);
+			buffer_get_varint(b, &ino);
+		}
 	
 		if(name) {
 			duc_dir_add_ent(dir, name, size, mode, dev, ino);

--- a/lib/private.h
+++ b/lib/private.h
@@ -3,7 +3,7 @@
 
 #include "duc.h"
 
-#define DUC_DB_VERSION "9"
+#define DUC_DB_VERSION "10"
 
 #ifndef HAVE_LSTAT
 #define lstat stat


### PR DESCRIPTION
Duc stores device id and inode number for all directory entries in the database, but only uses this information for traversing subdirectories.The info on regular files is never used, and can thus be omitted.

Space saving for the database seems to be about 15% on my tests, but merging this branch will break the database compatibility with earlier versions.
