### PR TITLE
Changed fatal errors from DUC_LOG_WRN to DUC_LOG_FTL

### DIFF
--- a/src/duc/cmd-graph.c
+++ b/src/duc/cmd-graph.c
@@ -60,13 +60,13 @@ static int graph_main(duc *duc, int argc, char **argv)
 
 	int r = duc_open(duc, opt_database, DUC_OPEN_RO);
 	if(r != DUC_OK) {
-		duc_log(duc, DUC_LOG_WRN, "%s", duc_strerror(duc));
+		duc_log(duc, DUC_LOG_FTL, "%s", duc_strerror(duc));
 		return -1;
 	}
 
 	duc_dir *dir = duc_dir_open(duc, path);
 	if(dir == NULL) {
-		duc_log(duc, DUC_LOG_WRN, "%s", duc_strerror(duc));
+		duc_log(duc, DUC_LOG_FTL, "%s", duc_strerror(duc));
 		return -1;
 	}
 
@@ -85,7 +85,7 @@ static int graph_main(duc *duc, int argc, char **argv)
 	}
 
 	if(f == NULL) {
-		duc_log(duc, DUC_LOG_WRN, "Error opening output file: %s", strerror(errno));
+		duc_log(duc, DUC_LOG_FTL, "Error opening output file: %s", strerror(errno));
 		return -1;
 	}
 

--- a/src/duc/cmd-gui.c
+++ b/src/duc/cmd-gui.c
@@ -161,7 +161,7 @@ static void do_gui(duc *duc, duc_graph *graph, duc_dir *dir)
 
 	Display *dpy = XOpenDisplay(NULL);
 	if(dpy == NULL) {
-		duc_log(duc, DUC_LOG_WRN, "ERROR: Could not open display");
+		duc_log(duc, DUC_LOG_FTL, "ERROR: Could not open display");
 		exit(1);
 	}
 
@@ -233,12 +233,13 @@ int gui_main(duc *duc, int argc, char *argv[])
 
 	int r = duc_open(duc, opt_database, DUC_OPEN_RO);
 	if(r != DUC_OK) {
+		duc_log(duc, DUC_LOG_FTL, "%s", duc_strerror(duc));
 		return -1;
 	}
 	
 	dir = duc_dir_open(duc, path);
 	if(dir == NULL) {
-		duc_log(duc, DUC_LOG_WRN, "%s", duc_strerror(duc));
+		duc_log(duc, DUC_LOG_FTL, "%s", duc_strerror(duc));
 		return -1;
 	}
 
@@ -266,7 +267,7 @@ static struct ducrc_option options[] = {
 
 int gui_main(int argc, char *argv[])
 {
-	duc_log(NULL, DUC_LOG_WRN, "'duc gui' is not supported on this platform");
+	duc_log(NULL, DUC_LOG_FTL, "'duc gui' is not supported on this platform");
 	return -1;
 }
 

--- a/src/duc/cmd-index.c
+++ b/src/duc/cmd-index.c
@@ -69,13 +69,13 @@ static int index_main(duc *duc, int argc, char **argv)
 	if(opt_progress) duc_index_req_set_progress_cb(req, progress_cb, NULL);
 
 	if(argc < 1) {
-		duc_log(duc, DUC_LOG_WRN, "Required index PATH missing.");
+		duc_log(duc, DUC_LOG_FTL, "Required index PATH missing.");
 		return -2;
 	}
 	
 	int r = duc_open(duc, opt_database, open_flags);
 	if(r != DUC_OK) {
-		duc_log(duc, DUC_LOG_WRN, "%s", duc_strerror(duc));
+		duc_log(duc, DUC_LOG_FTL, "%s", duc_strerror(duc));
 		return -1;
 	}
 

--- a/src/duc/cmd-info.c
+++ b/src/duc/cmd-info.c
@@ -25,6 +25,7 @@ static int info_db(duc *duc, char *file)
 
 	int r = duc_open(duc, file, DUC_OPEN_RO);
 	if(r != DUC_OK) {
+		duc_log(duc, DUC_LOG_FTL, "%s", duc_strerror(duc));
 		return -1;
 	}
 

--- a/src/duc/cmd-ui.c
+++ b/src/duc/cmd-ui.c
@@ -231,11 +231,13 @@ static int ui_main(duc *duc, int argc, char **argv)
 
 	int r = duc_open(duc, opt_database, DUC_OPEN_RO);
 	if(r != DUC_OK) {
+		duc_log(duc, DUC_LOG_FTL, "%s", duc_strerror(duc));
 		return -1;
 	}
 
 	duc_dir *dir = duc_dir_open(duc, path);
 	if(dir == NULL) {
+		duc_log(duc, DUC_LOG_FTL, "%s", duc_strerror(duc));
 		return -1;
 	}
 

--- a/src/duc/cmd-xml.c
+++ b/src/duc/cmd-xml.c
@@ -88,12 +88,13 @@ static int xml_main(duc *duc, int argc, char **argv)
 
 	int r = duc_open(duc, opt_database, DUC_OPEN_RO);
 	if(r != DUC_OK) {
+		duc_log(duc, DUC_LOG_FTL, "%s", duc_strerror(duc));
 		return -1;
 	}
 
 	duc_dir *dir = duc_dir_open(duc, path);
 	if(dir == NULL) {
-		duc_log(duc, DUC_LOG_WRN, "%s", duc_strerror(duc));
+		duc_log(duc, DUC_LOG_FTL, "%s", duc_strerror(duc));
 		return -1;
 	}
 

--- a/src/duc/main.c
+++ b/src/duc/main.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
 	
 	duc *duc = duc_new();
 	if(duc == NULL) {
-		duc_log(duc, DUC_LOG_WRN, "Error creating duc context");
+		duc_log(duc, DUC_LOG_FTL, "Error creating duc context");
 		return -1;
 	}
 

--- a/src/libduc/dir.c
+++ b/src/libduc/dir.c
@@ -157,7 +157,7 @@ duc_dir *duc_dir_open(struct duc *duc, const char *path)
 	}
 
 	if(l == 0) {
-		duc_log(duc, DUC_LOG_WRN, "Path %s not found in database", path_canon);
+		duc_log(duc, DUC_LOG_FTL, "Path %s not found in database", path_canon);
 		duc->err = DUC_E_PATH_NOT_FOUND;
 		free(path_canon);
 		return NULL;

--- a/src/libduc/duc.c
+++ b/src/libduc/duc.c
@@ -82,7 +82,7 @@ int duc_open(duc *duc, const char *path_db, duc_open_flags flags)
 
 	duc->db = db_open(path_db, flags, &duc->err);
 	if(duc->db == NULL) {
-		duc_log(duc, DUC_LOG_WRN, "Error opening: %s - %s", path_db, duc_strerror(duc));
+		duc_log(duc, DUC_LOG_FTL, "Error opening: %s - %s", path_db, duc_strerror(duc));
 		return -1;
 	}
 


### PR DESCRIPTION
After upgrade to latest version, I ran into a problem with the database version. However, it wasn't reported, since I was invoking with "-q".

Also added a few logging statements where missing.