### PR TITLE
RPM: update to release 1.4.2

### DIFF
--- a/build/duc.spec
+++ b/build/duc.spec
@@ -1,5 +1,5 @@
 %global name duc
-%global version 1.3.3
+%global version 1.4.2
 %global release 1
 
 Name:           %{name}
@@ -9,7 +9,7 @@ Summary:        Duc, a library and suite of tools for inspecting disk usage
 
 License:        GNU General Public License
 URL:            https://github.com/zevv/duc
-Source0:        https://github.com/zevv/duc/archive/master.tar.gz
+Source0:        https://github.com/zevv/duc/releases/download/%{version}/duc-%{version}.tar.gz
 
 BuildArch:      x86_64
 BuildRequires:  libtool autoconf
@@ -22,48 +22,33 @@ Duc maintains a database of accumulated sizes of directories of your file system
 and allows you to query this database with some tools,
 or create fancy graphs showing you where your bytes are.
 
-%package          devel
-Summary:          Development tools for %{name}
-Group:            Development/Libraries
-Requires:         %{name} = %{version}-%{release}
-
-%description devel
-Duc is a small library and a collection of tools for inspecting and visualizing
-disk usage.
-This is devel version.
-
 %prep
-%setup -n %{name}-master
+%setup
 
 %build
 autoreconf --install
-./configure --libdir=%{_libdir} --bindir=%{_bindir}
+./configure --libdir=%{_libdir} --bindir=%{_bindir} --mandir=%{_mandir}
 make
 
 %install
 make install DESTDIR=$RPM_BUILD_ROOT
-# added for %files fix
-echo "%%defattr(-, root, root)" >MANIFEST
-(cd $RPM_BUILD_ROOT; find . -type f -or -type l | sed -e s/^.// -e /^$/d) >>MANIFEST
 
 %post
-/sbin/ldconfig
 
 %clean
 rm -rf $RPM_BUILD_ROOT
 
-%files -f MANIFEST
-# old code breaks build, files not found
-#%defattr(-,root,root)
-#%{_libdir}/*.so*
-#%{_bindir}/%{name}
-
-#%files devel
-#%defattr(-,root,root)
-#%{_libdir}/*.*a
-#%{_bindir}/%{name}.debug
+%files
+%defattr(-,root,root)
+%{_bindir}/%{name}
+%{_mandir}/man1/%{name}.1.gz
 
 %changelog
+* Fri Dec 09 2016 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.4.2
+- Update to 1.4.2
+- Removed devel rpm
+- Cleanup spec
+
 * Mon Jun 29 2015 James Chang - 1.3.3
 - added ncurses-devel package requirement
 - fixed file not found for libs


### PR DESCRIPTION
- Move manual to standard mandir
- Remove devel package (it doesn't compile if there is no specific %files section)
- Remove call to ldconfig