### PR TITLE
Multiple updates to manual.txt

### DIFF
--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -127,7 +127,7 @@ Some notes:
   in the HTML page.
 
 * The options --header and --footer allow you to insert your own HTML code
-  before and after the main <div>.
+  before and after the main.
 
 The current CGI configuration is not very flexible, nor secure. It is not
 advised to run the CGI from public reachable web servers, use at your own risk.

--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -177,6 +177,18 @@ Then you can run the regular
 
 to the regular build of the software.
 
+A note for Redhat and derivates users. The package providing the development file
+for lmdb (lmdb-devel) does not include a lmdb.pc pkgconfig file. This could lead to
+errors during the configure phase:
+
+  checking for LMDB... no  
+  configure: error: Package requirements (lmdb) were not met:  
+                                                                                     
+To avoid the need to call pkg-config, you may set the environment variables          
+LMDB_CFLAGS and LMDB_LIBS:
+
+  LMDB_CFLAGS=" " LMDB_LIBS=-llmdb ./configure --with-db-backend=lmdb [ options ]  
+
 ## EXAMPLES
 
 

--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -165,15 +165,15 @@ key to toggle.
 If you use git clone to pull down the latest release, you will have to
 do the following:
 
-  git clone https://github.com/zevv/duc
-  cd duc
-  aclocal
-  automake --add-missing -c
+  git clone https://github.com/zevv/duc  
+  cd duc  
+  aclocal  
+  automake --add-missing -c  
 
 Then you can run the regular 
 
-  ./configure [ options ]
-  make
+  ./configure [ options ]  
+  make  
 
 to the regular build of the software.
 


### PR DESCRIPTION
Hi,

here are multiple updates suggestions to manual.txt:

- add trailing whitespaces for correct html rendering.
- add a compilation note for lmdb backend and redhat users.
- remove an necessary "<div>".