### PR TITLE
Add a --dry-run to the index command

### DIFF
--- a/src/duc/cmd-index.c
+++ b/src/duc/cmd-index.c
@@ -27,6 +27,7 @@ static int opt_max_depth = 0;
 static bool opt_one_file_system = false;
 static bool opt_progress = false;
 static bool opt_uncompressed = false;
+static bool opt_dryrun = false;
 static duc_index_req *req;
 
 
@@ -74,6 +75,7 @@ static int index_main(duc *duc, int argc, char **argv)
 	if(opt_hide_file_names) index_flags |= DUC_INDEX_HIDE_FILE_NAMES;
 	if(opt_check_hard_links) index_flags |= DUC_INDEX_CHECK_HARD_LINKS;
 	if(opt_uncompressed) open_flags &= ~DUC_OPEN_COMPRESS;
+	if(opt_dryrun) index_flags |= DUC_INDEX_DRY_RUN;
 
 	if(argc < 1) {
 		duc_log(duc, DUC_LOG_FTL, "Required index PATH missing.");
@@ -173,6 +175,7 @@ static struct ducrc_option options[] = {
 	  "levels of directories in the database to reduce the size of the index" },
 	{ &opt_one_file_system, "one-file-system", 'x', DUCRC_TYPE_BOOL,   "skip directories on different file systems" },
 	{ &opt_progress,        "progress",        'p', DUCRC_TYPE_BOOL,   "show progress during indexing" },
+	{ &opt_dryrun,          "dry-run",          0 , DUCRC_TYPE_BOOL,   "do not update database, just crawl" },
 	{ &opt_uncompressed,    "uncompressed",     0 , DUCRC_TYPE_BOOL,   "do not use compression for database",
           "Duc enables compression if the underlying database supports this. This reduces index size at the cost "
 	  "of slightly longer indexing time" },

--- a/src/libduc/duc.h
+++ b/src/libduc/duc.h
@@ -37,6 +37,7 @@ typedef enum {
 	DUC_INDEX_XDEV             = 1<<0, /* Do not cross device boundaries while indexing */
 	DUC_INDEX_HIDE_FILE_NAMES  = 1<<1, /* Hide file names */
 	DUC_INDEX_CHECK_HARD_LINKS = 1<<2, /* Count hard links only once during indexing */
+	DUC_INDEX_DRY_RUN          = 1<<3, /* Do not touch the database */
 } duc_index_flags;
 
 typedef enum {

--- a/src/libduc/index.c
+++ b/src/libduc/index.c
@@ -541,11 +541,13 @@ static void scanner_free(struct scanner *scanner)
 
 	}
 	
-	char key[32];
-	struct duc_devino *devino = &scanner->ent.devino;
-	size_t keyl = snprintf(key, sizeof(key), "%jx/%jx", (uintmax_t)devino->dev, (uintmax_t)devino->ino);
-	int r = db_put(duc->db, key, keyl, scanner->buffer->data, scanner->buffer->len);
-	if(r != 0) duc->err = r;
+    if (!(req->flags & DUC_INDEX_DRY_RUN)) {
+	    char key[32];
+	    struct duc_devino *devino = &scanner->ent.devino;
+	    size_t keyl = snprintf(key, sizeof(key), "%jx/%jx", (uintmax_t)devino->dev, (uintmax_t)devino->ino);
+	    int r = db_put(duc->db, key, keyl, scanner->buffer->data, scanner->buffer->len);
+	    if(r != 0) duc->err = r;
+    }
 
 	buffer_free(scanner->buffer);
 	closedir(scanner->d);
@@ -633,8 +635,10 @@ struct duc_index_report *duc_index(duc_index_req *req, const char *path, duc_ind
 	
 	/* Store report */
 
-	gettimeofday(&report->time_stop, NULL);
-	db_write_report(duc, report);
+    if (!(req->flags & DUC_INDEX_DRY_RUN)) {
+	    gettimeofday(&report->time_stop, NULL);
+	    db_write_report(duc, report);
+    }
 
 	free(path_canon);
 


### PR DESCRIPTION
This option prevents duc index to update its database. Could be useful
to test the crawling part of the command.