### PR TITLE
Fixed cmd-cgi 302 redirect

### DIFF
--- a/src/duc/cmd-cgi.c
+++ b/src/duc/cmd-cgi.c
@@ -319,6 +319,9 @@ static void do_index(duc *duc, duc_graph *graph, duc_dir *dir)
 			path = duc_dir_get_path(dir);
 			printf("Status: 302 Found\n");
 			printf("Location: ?path=%s\n", path);
+            printf("URI: ?path=%s\n", path);
+            printf("Connection: close\n");
+            printf("Content-type: text/html\n\n");
 			printf("\n");
 			return;
 		}


### PR DESCRIPTION
This fixes the 302 redirect when clicking x/y coordinates on the graph using CGI with the Chrome browser. Without content, Chrome will not redirect properly.