### PR TITLE
Make it XDG compliant

### DIFF
--- a/src/libduc/private.h
+++ b/src/libduc/private.h
@@ -30,12 +30,6 @@
   } while (0)
 #endif
 
-#ifdef WIN32
-#define FNAME_DUC_DB "duc.db"
-#else
-#define FNAME_DUC_DB ".duc.db"
-#endif
-
 struct duc {
 	struct db *db;
 	duc_errno err;


### PR DESCRIPTION
If a database is found at the legacy path, it will be used with a warning.

Fixes #103 