### PR TITLE
Do not append ".kct" to database filename made with kyoto db backend.

### DIFF
--- a/src/libduc/db-kyoto.c
+++ b/src/libduc/db-kyoto.c
@@ -46,7 +46,7 @@ struct db *db_open(const char *path_db, int flags, duc_errno *e)
 	}
 
 	char fname[DUC_PATH_MAX];
-	snprintf(fname, sizeof(fname), "%s.kct#opts=c", path_db);
+	snprintf(fname, sizeof(fname), "%s#type=kct#opts=c", path_db);
 
 	int r = kcdbopen(db->kdb, fname, mode);
 	if(r == 0) {


### PR DESCRIPTION
Allow any extension for kyoto database filename and do not append
".kct" at the end of the database filename.
The kyoto database format can be passed to kcdbopen() by adding
"#type=kct" to the database filename instead of being retrieved
from the extension.