### PR TITLE
fix ncurses headers on arch (at least)

### DIFF
--- a/src/duc/cmd-ui.c
+++ b/src/duc/cmd-ui.c
@@ -27,7 +27,12 @@
 #endif
 #endif
 #ifdef HAVE_LIBNCURSESW
+#ifdef HAVE_NCURSESW_NCURSES_H
 #include <ncursesw/ncurses.h>
+#endif
+#ifdef HAVE_NCURSES_H
+#include <ncurses.h>
+#endif
 #endif
 
 enum {


### PR DESCRIPTION
This makes duc compile on Arch Linux.