### PR TITLE
Implementation of a Concurrent Indexing Algorithm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,6 +165,11 @@ The X11 library was not found, which is needed for x11 gui support.
 fi
 
 
+AC_CHECK_LIB([pthread], [pthread_create],, [AC_MSG_ERROR([
+The pthread library was not found, which is needed for concurrency in the indexing algorithm.
+])])
+
+
 AC_CHECK_HEADERS([fcntl.h limits.h stdint.h stdlib.h string.h sys/ioctl.h unistd.h fnmatch.h termios.h])
 AC_CHECK_HEADERS([ncurses.h ncurses/ncurses.h ncursesw/ncurses.h])
 

--- a/src/duc/cmd-index.c
+++ b/src/duc/cmd-index.c
@@ -26,6 +26,8 @@ static bool opt_hide_file_names = false;
 static char *opt_username = NULL;
 static int opt_uid = 0;
 static int opt_max_depth = 0;
+static unsigned int opt_thread_count = 1;
+static unsigned int opt_cutoff_depth = 2;
 static bool opt_one_file_system = false;
 static bool opt_progress = false;
 static bool opt_uncompressed = false;
@@ -73,6 +75,8 @@ static int index_main(duc *duc, int argc, char **argv)
 	
 	if(opt_force) open_flags |= DUC_OPEN_FORCE;
 	if(opt_max_depth) duc_index_req_set_maxdepth(req, opt_max_depth);
+	if(opt_thread_count) duc_index_set_worker_count(opt_thread_count);
+	if(opt_cutoff_depth) duc_index_set_cutoff_depth(opt_cutoff_depth);
 	if(opt_one_file_system) index_flags |= DUC_INDEX_XDEV;
 	if(opt_hide_file_names) index_flags |= DUC_INDEX_HIDE_FILE_NAMES;
 	if(opt_check_hard_links) index_flags |= DUC_INDEX_CHECK_HARD_LINKS;
@@ -174,11 +178,16 @@ static struct ducrc_option options[] = {
 	  "VAL is a comma separated list of file system types as found in your systems fstab, for example ext3,ext4,dosfs" },
 	{ &opt_hide_file_names, "hide-file-names",  0 , DUCRC_TYPE_BOOL,   "hide file names in index (privacy)", 
 	  "the names of directories will be preserved, but the names of the individual files will be hidden" },
-	{ &opt_uid,             "uid",              'U', DUCRC_TYPE_INT,    "limit index to only files/dirs owned by uid" },
-	{ &opt_username,        "username",         'u', DUCRC_TYPE_STRING, "limit index to only files/dirs owned by username" },
+	{ &opt_uid,             "uid",             'U', DUCRC_TYPE_INT,    "limit index to only files/dirs owned by uid" },
+	{ &opt_username,        "username",        'u', DUCRC_TYPE_STRING, "limit index to only files/dirs owned by username" },
 	{ &opt_max_depth,       "max-depth",       'm', DUCRC_TYPE_INT,    "limit directory names to given depth" ,
 	  "when this option is given duc will traverse the complete file system, but will only the first VAL "
 	  "levels of directories in the database to reduce the size of the index" },
+	{ &opt_thread_count,    "thread-count",    't', DUCRC_TYPE_INT,    "stipulate index to use a given number of threads",
+	"when this option is given duc will multithread the indexing algorithm and use VAL workers to traverse the filesystem. "
+	"Default value is 1."},
+	{ &opt_cutoff_depth,    "cutoff-depth",    'c', DUCRC_TYPE_INT,    "ensures that each worker has at least VAL tasks before "
+	"other workers start taking its tasks", "In general the lower this is, the higher the concurrency. Default value is 2."},
 	{ &opt_one_file_system, "one-file-system", 'x', DUCRC_TYPE_BOOL,   "skip directories on different file systems" },
 	{ &opt_progress,        "progress",        'p', DUCRC_TYPE_BOOL,   "show progress during indexing" },
 	{ &opt_dryrun,          "dry-run",          0 , DUCRC_TYPE_BOOL,   "do not update database, just crawl" },

--- a/src/libduc/buffer.h
+++ b/src/libduc/buffer.h
@@ -3,9 +3,10 @@
 
 struct buffer {
 	uint8_t *data;
-	size_t max;
-	size_t len;
-	size_t ptr;
+	pthread_rwlock_t data_lock;
+	_Atomic size_t max;
+	_Atomic size_t len;
+	_Atomic size_t ptr;
 };
 
 struct buffer *buffer_new(void *data, size_t len);

--- a/src/libduc/db.c
+++ b/src/libduc/db.c
@@ -34,9 +34,8 @@ duc_errno db_write_report(duc *duc, const struct duc_index_report *report)
 		} else {
 			db_put(duc->db, "duc_index_reports", 17, report->path, sizeof(report->path));
 		}
-	} else {
-		free(tmp);
 	}
+	free(tmp);
 
 	struct buffer *b = buffer_new(NULL, 0);
 

--- a/src/libduc/duc.h
+++ b/src/libduc/duc.h
@@ -90,18 +90,18 @@ struct duc_devino {
 };
 
 struct duc_size {
-	off_t actual;
-	off_t apparent;
-	off_t count;
+	_Atomic off_t actual;
+	_Atomic off_t apparent;
+	_Atomic off_t count;
 };
 
 struct duc_index_report {
-	char path[DUC_PATH_MAX];        /* Indexed path */
+	char path[DUC_PATH_MAX];    /* Indexed path */
 	struct duc_devino devino;   /* Index top device id and inode number */
 	struct timeval time_start;  /* Index start time */
 	struct timeval time_stop;   /* Index finished time */
-	size_t file_count;          /* Total number of files indexed */
-	size_t dir_count;           /* Total number of directories indexed */
+	_Atomic size_t file_count;  /* Total number of files indexed */
+	_Atomic size_t dir_count;   /* Total number of directories indexed */
 	struct duc_size size;       /* Total size */
 };
 
@@ -150,6 +150,8 @@ int duc_index_req_add_fstype_include(duc_index_req *req, const char *types);
 int duc_index_req_add_fstype_exclude(duc_index_req *req, const char *types);
 int duc_index_req_set_maxdepth(duc_index_req *req, int maxdepth);
 int duc_index_req_set_progress_cb(duc_index_req *req, duc_index_progress_cb fn, void *ptr);
+int duc_index_set_cutoff_depth(unsigned int cutoff_depth);
+int duc_index_set_worker_count(unsigned int worker_count);
 struct duc_index_report *duc_index(duc_index_req *req, const char *path, duc_index_flags flags);
 int duc_index_req_free(duc_index_req *req);
 int duc_index_report_free(struct duc_index_report *rep);

--- a/src/libduc/index.c
+++ b/src/libduc/index.c
@@ -8,6 +8,7 @@
 #include <pwd.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -17,6 +18,7 @@
 #include <time.h>
 #include <sys/time.h>
 #include <unistd.h>
+#include <pthread.h>
 #ifdef HAVE_FNMATCH_H
 #include <fnmatch.h>
 #endif
@@ -27,6 +29,26 @@
 #include "uthash.h"
 #include "utlist.h"
 #include "buffer.h"
+
+struct stack_node {
+	size_t length;
+	struct stack_node *next;
+	struct scanner* scanner;
+};
+
+unsigned int WORKER_COUNT = 1;
+unsigned int CUTOFF_DEPTH = 2;
+pthread_t *worker_threads;
+struct stack_node **worker_stacks;
+pthread_rwlock_t *worker_rw_locks;
+pthread_mutex_t database_write_lock;
+
+/*
+ * Maintains a count of the number of workers that are polling other workers for work, checking
+ * if they need to terminate. Once this count reaches <WORKER_COUNT>, it is a signal for all
+ * the workers to terminate.
+ */
+_Atomic unsigned int num_workers_terminating;
 
 struct hard_link {
 	struct duc_devino devino;
@@ -49,12 +71,12 @@ struct duc_index_req {
 	struct exclude *exclude_list;
 	duc_dev_t dev;
 	duc_index_flags flags;
-	int maxdepth;
-        uid_t uid;
-        const char *username;
+	_Atomic int maxdepth;
+	uid_t uid;
+	const char *username;
 	duc_index_progress_cb progress_fn;
 	void *progress_fndata;
-	int progress_n;
+	_Atomic int progress_n;
 	struct timeval progress_interval;
 	struct timeval progress_time;
 	struct hard_link *hard_link_map;
@@ -65,17 +87,55 @@ struct duc_index_req {
 
 struct scanner {
 	struct scanner *parent;
-	int depth;
-	DIR *d;
+	_Atomic int depth;
 	struct buffer *buffer;
 	struct duc *duc;
 	struct duc_index_req *req;
 	struct duc_index_report *rep;
 	struct duc_dirent ent;
+	const char *absolute_path;                /* Absolute path of the dirent this scanner refers to */
+	_Atomic unsigned int completed_children;  /* Number of children of this node that completed */
+	_Atomic unsigned int num_children;        /* Number of children that this node has */
+	_Atomic bool done_processing;             /* Indicates whether the node finished processing */
 };
 
 
-static void scanner_free(struct scanner *scanner);
+void stack_push(unsigned int worker_num, struct scanner *scanner)
+{
+	struct stack_node *old_head = worker_stacks[worker_num];
+	struct stack_node *new_head = duc_malloc(sizeof(struct stack_node));
+	new_head->next = old_head;
+	new_head->scanner = scanner;
+	new_head->length = old_head == NULL ? 1 : old_head->length + 1;
+	worker_stacks[worker_num] = new_head;
+}
+
+
+struct scanner *stack_pop(unsigned int worker_num)
+{
+	struct stack_node *old_head = worker_stacks[worker_num];
+	if (!old_head) {
+		return NULL;
+	}
+
+	struct scanner *scanner = old_head->scanner;
+	worker_stacks[worker_num] = old_head->next;
+
+	duc_free(old_head);
+	return scanner;
+}
+
+
+size_t stack_len(struct stack_node *head)
+{
+	return head == NULL ? 0 : head->length;
+}
+
+
+bool stack_empty(struct stack_node *head)
+{
+	return !head;
+}
 
 
 duc_index_req *duc_index_req_new(duc *duc)
@@ -147,7 +207,7 @@ static struct fstype *add_fstype(duc_index_req *req, const char *types, struct f
 	char *type = strtok(types_copy, ",");
 	while(type) {
 		struct fstype *fstype;
-		fstype = duc_malloc(sizeof *fstype);
+		fstype = duc_malloc(sizeof(*fstype));
 		fstype->type = duc_strdup(type);
 		HASH_ADD_KEYPTR(hh, list, fstype->type, strlen(fstype->type), fstype);
 		type = strtok(NULL, ",");
@@ -177,8 +237,28 @@ int duc_index_req_set_maxdepth(duc_index_req *req, int maxdepth)
 	return 0;
 }
 
-/* We set both uid and username, since we cannot use -1 UID to check wether we're 
-   limiting the search to just a specific UID, but we use UID for quicker compares. */
+
+int duc_index_set_worker_count(unsigned int worker_count)
+{
+	WORKER_COUNT = worker_count;
+	worker_threads = duc_malloc(sizeof(pthread_t) * WORKER_COUNT);
+	worker_stacks = duc_malloc(sizeof(struct stack_node *) * WORKER_COUNT);
+	worker_rw_locks = duc_malloc(sizeof(pthread_rwlock_t) * WORKER_COUNT);
+	return 0;
+}
+
+
+int duc_index_set_cutoff_depth(unsigned int cutoff_depth)
+{
+	CUTOFF_DEPTH = cutoff_depth;
+	return 0;
+}
+
+
+/* 
+ * We set both uid and username, since we cannot use -1 UID to check wether we're 
+ * limiting the search to just a specific UID, but we use UID for quicker compares.
+ */
 
 int duc_index_req_set_username(duc_index_req *req, const char *username )
 {
@@ -252,7 +332,7 @@ static void st_to_size(struct stat *st, struct duc_size *s)
 
 
 /*
- * Conver struct stat to duc_devino. Windows does not support inodes
+ * Convert struct stat to duc_devino. Windows does not support inodes
  * and will always put 0 in st_ino. We fake inodes here by simply using
  * an incrementing counter. This *will* cause problems when re-indexing
  * existing databases. If anyone knows a better method to simulate
@@ -283,7 +363,7 @@ static int is_duplicate(struct duc_index_req *req, struct duc_devino *devino)
 	HASH_FIND(hh, req->hard_link_map, devino, sizeof(*devino), h);
 	if(h) return 1;
 
-	h = duc_malloc(sizeof *h);
+	h = duc_malloc(sizeof(*h));
 	h->devino = *devino;
 	HASH_ADD(hh, req->hard_link_map, devino, sizeof(h->devino), h);
 	return 0;
@@ -306,6 +386,34 @@ static void report_skip(struct duc *duc, const char *name, const char *fmt, ...)
 }
 
 
+/* 
+ * Given a parent scanner and a child's name, this function returns the
+ * absolute path to the child.
+ */
+
+char *get_absolute_path(struct scanner *scanner_parent, char *child_name)
+{
+	char *absolute_path;
+	size_t path_suffix_size = strlen(child_name);
+
+	if (!scanner_parent) {
+		absolute_path = duc_malloc0(sizeof(char) * (path_suffix_size + 1));
+		strcpy(absolute_path, child_name);
+		return absolute_path;
+	}
+
+	/*
+	 * The absolute path referenced by a child scanner should be the absolute
+	 * path referenced by the parent scanner + '/' + the name of the file
+	 */
+
+	size_t parent_absolute_path_size = strlen(scanner_parent->absolute_path);
+	absolute_path = duc_malloc0(sizeof(char) * (parent_absolute_path_size + path_suffix_size + 2));
+	sprintf(absolute_path, "%s/%s", scanner_parent->absolute_path, child_name);
+	return absolute_path;
+}
+
+
 /*
  * Check if this file system type should be scanned, depending on the
  * fstypes_include and fstypes_exclude lists. If neither has any entries, all
@@ -321,7 +429,6 @@ static int is_fstype_allowed(struct duc_index_req *req, const char *name)
 	}
 
 	/* Find file system type */
-
 	char path_full[DUC_PATH_MAX];
         char *res = realpath(name, path_full);
 	if (res == NULL) {
@@ -364,13 +471,18 @@ static int is_fstype_allowed(struct duc_index_req *req, const char *name)
  * Open dir and read file status 
  */
 
-static struct scanner *scanner_new(struct duc *duc, struct scanner *scanner_parent, const char *path, struct stat *st)
+static struct scanner *scanner_new(struct duc *duc, struct scanner *scanner_parent, const char *path, const char *dirent_name, struct stat *st)
 {
 	struct scanner *scanner;
-	scanner = duc_malloc0(sizeof *scanner);
+	scanner = duc_malloc0(sizeof(*scanner));
 
 	struct stat st2;
 	struct duc_devino devino_parent = { 0, 0 };
+
+	scanner->absolute_path = path;
+	scanner->done_processing = false;
+	scanner->num_children = 0;
+	scanner->completed_children = 0;
 
 	if(scanner_parent) {
 		scanner->depth = scanner_parent->depth + 1;
@@ -379,30 +491,26 @@ static struct scanner *scanner_new(struct duc *duc, struct scanner *scanner_pare
 		scanner->rep = scanner_parent->rep;
 		devino_parent = scanner_parent->ent.devino;
 	} else {
-		int r = lstat(path, &st2);
+		int r = lstat(scanner->absolute_path, &st2);
 		if(r == -1) {
 			duc_log(duc, DUC_LOG_WRN, "Error statting %s: %s", path, strerror(errno));
+			if(errno == ENOENT) duc->err = DUC_E_PATH_NOT_FOUND;
 			goto err;
 		}
 		st = &st2;
 	}
 	
-	scanner->d = opendir(path);
-	if(scanner->d == NULL) {
-		report_skip(duc, path, strerror(errno));
-		goto err;
-	}
-	
+
 	scanner->duc = duc;
 	scanner->parent = scanner_parent;
 	scanner->buffer = buffer_new(NULL, 32768);
 
-	scanner->ent.name = duc_strdup(path);
+	scanner->ent.name = duc_strdup(dirent_name);
 	scanner->ent.type = DUC_FILE_TYPE_DIR,
 	st_to_devino(st, &scanner->ent.devino);
 	st_to_size(st, &scanner->ent.size);
 	scanner->ent.size.apparent = 0;
-		
+
 	buffer_put_dir(scanner->buffer, &devino_parent, st->st_mtime);
 
 	duc_log(duc, DUC_LOG_DMP, ">> %s", scanner->ent.name);
@@ -410,143 +518,8 @@ static struct scanner *scanner_new(struct duc *duc, struct scanner *scanner_pare
 	return scanner;
 
 err:
-	if(scanner->d) closedir(scanner->d);
 	if(scanner) free(scanner);
 	return NULL;
-}
-
-
-static void scanner_scan(struct scanner *scanner_dir)
-{
-        int r;
-        struct duc *duc = scanner_dir->duc;
-	struct duc_index_req *req = scanner_dir->req;
-	struct duc_index_report *report = scanner_dir->rep; 	
-
-	report->dir_count ++;
-	duc_size_accum(&report->size, &scanner_dir->ent.size);
-
-	r = chdir(scanner_dir->ent.name);
-	if(r != 0) {
-		report_skip(duc, scanner_dir->ent.name, strerror(errno));
-		return;
-	}
-
-	/* Iterate directory entries */
-
-	struct dirent *e;
-	while( (e = readdir(scanner_dir->d)) != NULL) {
-
-		/* Skip . and .. */
-
-		char *name = e->d_name;
-
-		if(name[0] == '.') {
-			if(name[1] == '\0') continue;
-			if((name[1] == '.') && (name[2] == '\0')) continue;
-		}
-
-		if(match_exclude(name, req->exclude_list)) {
-			report_skip(duc, name, "Excluded by user");
-			continue;
-		}
-
-		/* Get file info. Derive the file type from st.st_mode. It
-		 * seems that we cannot trust e->d_type because it is not
-		 * guaranteed to contain a sane value on all file system types.
-		 * See the readdir() man page for more details */
-
-		struct stat st_ent;
-		int r = lstat(name, &st_ent);
-		if(r == -1) {
-			duc_log(duc, DUC_LOG_WRN, "Error statting %s: %s", name, strerror(errno));
-			continue;
-		}
-
-		/* If this dirent lies on a different device, check the file system type of the new
-		 * device and skip if it is not on the list of approved types */
-
-		if(st_ent.st_dev != scanner_dir->ent.devino.dev) {
-			if(!is_fstype_allowed(req, name)) {
-				continue;
-			}
-		}
-
-		/* Are we looking for data for only a specific user? */
-		if(req->username) {
-		    if(st_ent.st_uid != req->uid) {
-			continue;
-		    }
-		}
-		
-		/* Create duc_dirent from readdir() and fstatat() results */
-		
-		struct duc_dirent ent;
-		ent.name = name;
-		ent.type = st_to_type(st_ent.st_mode);
-		st_to_devino(&st_ent, &ent.devino);
-		st_to_size(&st_ent, &ent.size);
-
-		/* Skip hard link duplicates for any files with more then one hard link */
-
-		if((ent.type != DUC_FILE_TYPE_DIR) && (req->flags & DUC_INDEX_CHECK_HARD_LINKS) &&
-		   (st_ent.st_nlink > 1) && is_duplicate(req, &ent.devino)) {
-			continue;
-		}
-
-
-		/* Check if we can cross file system boundaries */
-
-		if((ent.type == DUC_FILE_TYPE_DIR) && (req->flags & DUC_INDEX_XDEV) &&
-		   (st_ent.st_dev != req->dev)) {
-			report_skip(duc, name, "Not crossing file system boundaries");
-			continue;
-		}
-
-
-		/* Calculate size of this dirent */
-		
-		if(ent.type == DUC_FILE_TYPE_DIR) {
-
-			/* Open and scan child directory */
-
-			struct scanner *scanner_ent = scanner_new(duc, scanner_dir, name, &st_ent);
-			if(scanner_ent == NULL)
-				continue;
-
-			scanner_scan(scanner_ent);
-			scanner_free(scanner_ent);
-
-		} else {
-
-			duc_size_accum(&scanner_dir->ent.size, &ent.size);
-			duc_size_accum(&report->size, &ent.size);
-
-			report->file_count ++;
-
-			duc_log(duc, DUC_LOG_DMP, "  %c %jd %jd %s", 
-					duc_file_type_char(ent.type), ent.size.apparent, ent.size.actual, name);
-
-
-			/* Optionally hide file names */
-
-			if(req->flags & DUC_INDEX_HIDE_FILE_NAMES) ent.name = "<FILE>";
-		
-
-			/* Store record */
-
-			if((req->maxdepth == 0) || (scanner_dir->depth < req->maxdepth)) {
-				buffer_put_dirent(scanner_dir->buffer, &ent);
-			}
-		}
-	}
-
-	r = chdir("..");
-	if(r != 0) {
-		report_skip(duc, scanner_dir->ent.name, strerror(errno));
-		return;
-	}
-
 }
 
 
@@ -555,7 +528,7 @@ static void scanner_free(struct scanner *scanner)
 	struct duc *duc = scanner->duc;
 	struct duc_index_req *req = scanner->req;
 	struct duc_index_report *report = scanner->rep; 	
-	
+
 	duc_log(duc, DUC_LOG_DMP, "<< %s actual:%jd apparent:%jd", 
 			scanner->ent.name, scanner->ent.size.apparent, scanner->ent.size.actual);
 
@@ -565,13 +538,10 @@ static void scanner_free(struct scanner *scanner)
 		if((req->maxdepth == 0) || (scanner->depth < req->maxdepth)) {
 			buffer_put_dirent(scanner->parent->buffer, &scanner->ent);
 		}
-
 	}
-	
+
 	/* Progress reporting */
-
 	if(req->progress_fn) {
-
 		if((!scanner->parent) || (req->progress_n++ == 100)) {
 			
 			struct timeval t_now;
@@ -583,19 +553,21 @@ static void scanner_free(struct scanner *scanner)
 			}
 			req->progress_n = 0;
 		}
-
 	}
-	
+
 	if(!(req->flags & DUC_INDEX_DRY_RUN)) {
 		char key[32];
 		struct duc_devino *devino = &scanner->ent.devino;
 		size_t keyl = snprintf(key, sizeof(key), "%jx/%jx", (uintmax_t)devino->dev, (uintmax_t)devino->ino);
+		pthread_mutex_lock(&database_write_lock);
 		int r = db_put(duc->db, key, keyl, scanner->buffer->data, scanner->buffer->len);
+		pthread_mutex_unlock(&database_write_lock);
 		if(r != 0) duc->err = r;
 	}
 
+	duc_free((void *)scanner->absolute_path);
+
 	buffer_free(scanner->buffer);
-	closedir(scanner->d);
 	duc_free(scanner->ent.name);
 	duc_free(scanner);
 }
@@ -613,6 +585,7 @@ static void read_mounts(duc_index_req *req)
 
 	if(f == NULL) {
 		duc_log(req->duc, DUC_LOG_FTL, "Unable to get list of mounted file systems");
+		return;
 	}
 
 	char buf[DUC_PATH_MAX];
@@ -623,13 +596,358 @@ static void read_mounts(duc_index_req *req)
 		char *type = strtok(NULL, " ");
 		if(path && type) {
 			struct fstype *fstype;
-			fstype = duc_malloc(sizeof *fstype);
+			fstype = duc_malloc(sizeof(*fstype));
 			fstype->type = duc_strdup(type);
 			fstype->path = duc_strdup(path);
 			HASH_ADD_KEYPTR(hh, req->fstypes_mounted, fstype->path, strlen(fstype->path), fstype);
 		}
 	}
 	fclose(f);
+}
+
+
+void write_lock_worker_stack(unsigned int worker_num)
+{
+	assert(worker_num < WORKER_COUNT);
+
+	pthread_rwlock_wrlock(&worker_rw_locks[worker_num]);
+}
+
+
+void read_lock_worker_stack(unsigned int worker_num)
+{
+	assert(worker_num < WORKER_COUNT);
+
+	pthread_rwlock_rdlock(&worker_rw_locks[worker_num]);
+}
+
+
+void unlock_worker_stack(unsigned int worker_num)
+{
+	assert(worker_num < WORKER_COUNT);
+
+	pthread_rwlock_unlock(&worker_rw_locks[worker_num]);
+}
+
+
+void free_nodes(struct scanner *scanner)
+{
+	/*
+	 * LOGIC:
+	 * This bottom-up algorithm to free nodes. The worker starts freeing at node <scanner> and walks
+	 * up the tree, ensuring that topological order is maintained. The algorithm is as follows:
+
+	 * LOOP: The worker frees this node and keeps track of its parent.
+	 * The <completed_children> count of the node's parent is incremented (since the child was freed).
+	 * If the freed node's parent is not done processing:
+	 * 		The parent obviously cannot be freed because it hasn't finished processing. And so
+	 * 		the loop is broken.
+	 * Otherwise:
+	 * 		The freeing of the parent was left as a duty to the LAST CHILD to finish.
+	 * 		So the worker checks if this node is the last child. If it is, LOOP is repeated with
+	 * 		the parent being the new node. Otherwise, the loop terminates.
+	 */
+
+	struct scanner* s = scanner->parent;
+	scanner_free(scanner);
+	while(s) {
+		s->completed_children++;
+
+		/*
+		 * If the parent hasn't finished processing, then this child cannot free it.
+		 * So the child can ignore its parent in this scenario.
+		 */
+		if(! s->done_processing) break;
+		s->done_processing = true;
+
+		/*
+		 * If the parent is done processing but this child is not the last child to process,
+		 * then the child cannot free the parent (top sort demands ALL children finish before parent).
+		 */
+		if (s->completed_children != s->num_children) break;
+
+		/* Free the parent */
+		struct scanner* new_parent = s->parent;
+		scanner_free(s);
+
+		s = new_parent;
+	}
+}
+
+
+/*
+ * Adds all relevant children that need to be processed onto <worker_num>'s DFS
+ * stack, and returns whether <scanner> is a leaf node i.e whether it has any children.
+ */
+
+bool process_node(unsigned int worker_num, struct scanner *scanner)
+{
+	DIR *dr = opendir(scanner->absolute_path);
+	if (dr == NULL) return true;
+
+	struct dirent *de;
+	bool is_leaf = true;
+	while( (de = readdir(dr)) != NULL ) {
+		char *dirent_name = de->d_name;
+		struct duc *duc = scanner->duc;
+		struct duc_index_req *req = scanner->req;
+		struct duc_index_report *report = scanner->rep;
+
+		if(strcmp(dirent_name, ".") == 0 || strcmp(dirent_name, "..") == 0) {
+			continue;
+		}
+		
+		if(match_exclude(dirent_name, req->exclude_list)) {
+			report_skip(duc, dirent_name, "Excluded by user");
+			continue;
+		}
+
+		/* 
+		 * Get file info. Derive the file type from st.st_mode. It
+		 * seems that we cannot trust e->d_type because it is not
+		 * guaranteed to contain a sane value on all file system types.
+		 * See the readdir() man page for more details
+		 */
+		char *absolute_path = get_absolute_path(scanner, dirent_name);
+		struct stat st_ent;
+		int r = lstat(absolute_path, &st_ent);
+		if(r == -1) {
+			duc_log(duc, DUC_LOG_WRN, "Error statting %s: %s", absolute_path, strerror(errno));
+			duc_free(absolute_path);
+			continue;
+		}
+
+		/* 
+		 * If this dirent lies on a different device, check the file system type of the new
+		 * device and skip if it is not on the list of approved types
+		 */
+		if(st_ent.st_dev != scanner->ent.devino.dev) {
+			if(!is_fstype_allowed(req, dirent_name)) {
+				duc_free(absolute_path);
+				continue;
+			}
+		}
+
+		/* Are we looking for data for only a specific user? */
+		if(req->username) {
+			if(st_ent.st_uid != req->uid) {
+				duc_free(absolute_path);
+				continue;
+			}
+		}
+		
+		/* Create duc_dirent from readdir() and fstatat() results */
+		struct duc_dirent ent;
+		ent.name = dirent_name;
+		ent.type = st_to_type(st_ent.st_mode);
+		st_to_devino(&st_ent, &ent.devino);
+		st_to_size(&st_ent, &ent.size);
+
+		/* Skip hard link duplicates for any files with more then one hard link */
+		if((ent.type != DUC_FILE_TYPE_DIR) && (req->flags & DUC_INDEX_CHECK_HARD_LINKS) &&
+			(st_ent.st_nlink > 1) && is_duplicate(req, &ent.devino)) {
+			duc_free(absolute_path);
+			continue;
+		}
+
+
+		/* Check if we can cross file system boundaries */
+		if((ent.type == DUC_FILE_TYPE_DIR) && (req->flags & DUC_INDEX_XDEV) &&
+			(st_ent.st_dev != req->dev)) {
+			report_skip(duc, dirent_name, "Not crossing file system boundaries");
+			duc_free(absolute_path);
+			continue;
+		}
+		
+
+		if(ent.type == DUC_FILE_TYPE_DIR) {
+
+			/* Open and scan child directory */
+			struct scanner *child_scanner = scanner_new(duc, scanner, absolute_path, dirent_name, &st_ent);
+
+			if(child_scanner == NULL) {
+				duc_free(absolute_path);
+				continue;
+			}
+
+			/* Obtain the write lock and push the child onto the stack */
+			write_lock_worker_stack(worker_num);
+			stack_push(worker_num, child_scanner);
+			unlock_worker_stack(worker_num);
+
+			is_leaf = false;
+			++scanner->num_children;
+			++report->dir_count;
+		} else {
+			duc_size_accum(&scanner->ent.size, &ent.size);
+			duc_size_accum(&report->size, &ent.size);
+
+			++report->file_count;
+
+			duc_log(duc, DUC_LOG_DMP, "  %c %jd %jd %s", 
+					duc_file_type_char(ent.type), ent.size.apparent, ent.size.actual, dirent_name);
+
+			duc_free(absolute_path);
+
+			/* Optionally hide file names */
+			if(req->flags & DUC_INDEX_HIDE_FILE_NAMES) ent.name = "<FILE>";
+		
+
+			/* Store record */
+			if((req->maxdepth == 0) || (scanner->depth < req->maxdepth)) {
+				buffer_put_dirent(scanner->buffer, &ent);
+			}
+		}
+	}
+	closedir(dr);
+	return is_leaf;
+}
+
+
+void dfs_worker(unsigned int worker_num)
+{
+	/*
+	 * LOGIC:
+	 * Our goal is to ensure a concurrent topological sort, so that parent nodes can aggregate stats of their children.
+	 * Let us define a node "processing" as the process whereby a worker puts the node's relevant children onto its DFS stack.
+	 * Each node maintains a count of the number of children it possesses <num_children>, a boolean to indicate whether it is
+	 * finished processing <done_processing>, as well as a count of its children which finished processing <completed_children>.
+	 * 
+	 * When a node is being processed by a worker:
+	 * 		Each child it possesses is placed onto the DFS stack and <num_children> is incremented.
+	 * After processing:
+	 * 		The worker checks if either of two conditions are true for the node:
+	 * 			- If the node is a leaf, then it has no dependencies in the topological sort, and so it can be freed.
+	 * 			- If the node's <completed_children> count equals the <num_children>, then this means that the children
+	 * 			  all finished processing (possible due to concurrency of the algorithm). Then topological order is guaranteed,
+	 * 			  and so the node can be freed.
+	 * 		Otherwise:
+	 * 			- The node cannot yet be freed, otherwise topological order will be violated. Thus, the worker marks the node
+	 * 			  as <done_processing>, and leaves the freeing of the node as a duty to the LAST CHILD of the node which finishes
+	 * 			  processing.
+	 */
+
+	while(true) {
+		/* Pop a new node off the DFS stack */
+		write_lock_worker_stack(worker_num);
+		if (stack_empty(worker_stacks[worker_num])) {
+			unlock_worker_stack(worker_num);
+			break;
+		}
+		struct scanner *scanner = stack_pop(worker_num);
+		unlock_worker_stack(worker_num);
+
+		/* Process the node */
+		bool is_leaf = process_node(worker_num, scanner);
+
+		/* Run the free algorithm on the node */
+		if (is_leaf ||
+			!scanner->done_processing &&
+			scanner->completed_children == scanner->num_children) {
+			free_nodes(scanner);
+		} else {
+			scanner->done_processing = true;
+		}
+		return;
+	}
+}
+
+
+/*
+ * This function polls all workers for work to add to <worker_num>'s stack. 
+ * If there is work available on another worker's stack and the stack size exceeds
+ * the cutoff depth, then work is taken from the other worker.
+ *
+ * Returns false if the worker should fully terminate, i.e. if all other
+ * workers also have no work left, and are looking for work.
+ */
+
+bool get_work_for(unsigned int worker_num)
+{
+	unsigned int target = 0;
+	++num_workers_terminating;
+	while (num_workers_terminating != WORKER_COUNT) {
+		/* 'Target' is the target processor that we are taking tasks from */
+		target = (target + 1) % WORKER_COUNT;
+		if (target == worker_num) continue;
+		write_lock_worker_stack(target);
+
+		/* If this target processor has too many tasks then take one of its tasks */
+		if (stack_len(worker_stacks[target]) > CUTOFF_DEPTH) {
+			--num_workers_terminating;
+			struct scanner* target_task = stack_pop(target);
+			unlock_worker_stack(target);
+			write_lock_worker_stack(worker_num);
+			stack_push(worker_num, target_task);
+			unlock_worker_stack(worker_num);
+			return true;
+		}
+
+		unlock_worker_stack(target);
+	}
+
+	return false;
+}
+
+
+void *worker_main(void *worker_num_v)
+{
+	unsigned int worker_num = (uintptr_t) worker_num_v;
+
+	while (true) {
+		read_lock_worker_stack(worker_num);
+
+		if (stack_empty(worker_stacks[worker_num])) {
+			unlock_worker_stack(worker_num);
+
+			/*
+			 * If there is no work for this worker, then poll other workers for work.
+			 * If the function returns false, it is an indicator to terminate.
+			 */
+			if (!get_work_for(worker_num)) break;
+		} else {
+			unlock_worker_stack(worker_num);
+		}
+
+		dfs_worker(worker_num);
+	}
+
+	return NULL;
+}
+
+
+void initialize_workers(void)
+{
+	for (unsigned int i = 0; i < WORKER_COUNT; i++) {
+		/* Initialize the worker's stack */
+		worker_stacks[i] = NULL;
+
+		/* Initialize the mutex for the worker's stack */
+		pthread_rwlock_init(&worker_rw_locks[i], NULL);
+	}
+}
+
+
+void create_worker_pool(struct scanner *scanner)
+{
+	for (uintptr_t worker_num = 0; worker_num < WORKER_COUNT; worker_num++) {
+		assert(
+			pthread_create(
+				&worker_threads[worker_num],
+				NULL,
+				&worker_main,
+				(void *) worker_num
+			)
+		== 0);
+	}
+}
+
+
+void join_workers(void)
+{
+	for (unsigned int i = 0; i < WORKER_COUNT; i++) {
+		pthread_join(worker_threads[i], NULL);
+	}
 }
 
 
@@ -640,7 +958,6 @@ struct duc_index_report *duc_index(duc_index_req *req, const char *path, duc_ind
 	req->flags = flags;
 
 	/* Canonicalize index path */
-
 	char *path_canon = duc_canonicalize_path(path);
 	if(path_canon == NULL) {
 		duc_log(duc, DUC_LOG_WRN, "Error converting path %s: %s", path, strerror(errno));
@@ -651,45 +968,45 @@ struct duc_index_report *duc_index(duc_index_req *req, const char *path, duc_ind
 	}
 
 	/* Create report */
-	
 	struct duc_index_report *report = duc_malloc0(sizeof(struct duc_index_report));
 	gettimeofday(&report->time_start, NULL);
 	snprintf(report->path, sizeof(report->path), "%s", path_canon);
 
 	/* Read mounted file systems to find fs types */
-
 	if(req->fstypes_include || req->fstypes_exclude) {
 		read_mounts(req);
 	}
 
-	/* Recursively index subdirectories */
-
-	struct scanner *scanner = scanner_new(duc, NULL, path_canon, NULL);
-
-	if(scanner) {
-		scanner->req = req;
-		scanner->rep = report;
+	/* Index subdirectories using a worker pool with a parallel topological sort */
+	struct scanner *scanner = scanner_new(duc, NULL, path_canon, path_canon, NULL);
+	if(! scanner) return NULL;
 	
-		req->dev = scanner->ent.devino.dev;
-		report->devino = scanner->ent.devino;
+	scanner->req = req;
+	scanner->rep = report;
+	req->dev = scanner->ent.devino.dev;
+	report->devino = scanner->ent.devino;
 
-		scanner_scan(scanner);
-		gettimeofday(&report->time_stop, NULL);
-		scanner_free(scanner);
-	}
+	/* Initialize, create, and join the worker pool */
+	pthread_mutex_init(&database_write_lock, NULL);
+	initialize_workers();
+	stack_push(0, scanner); /* Push first task onto worker 0's stack */
+	create_worker_pool(scanner);
+	join_workers();
 	
+	/* Free resources */
+	pthread_mutex_destroy(&database_write_lock);
+	duc_free(worker_threads);
+	duc_free(worker_stacks);
+	duc_free(worker_rw_locks);
+
 	/* Store report */
-
 	if(!(req->flags & DUC_INDEX_DRY_RUN)) {
 		gettimeofday(&report->time_stop, NULL);
 		db_write_report(duc, report);
 	}
 
-	free(path_canon);
-
 	return report;
 }
-
 
 
 int duc_index_report_free(struct duc_index_report *rep)
@@ -702,4 +1019,3 @@ int duc_index_report_free(struct duc_index_report *rep)
 /*
  * End
  */
-


### PR DESCRIPTION
# Aim
This change aims to modify the indexing algorithm for DUC to add concurrency. It does this by implementing a concurrent topological sort. This also closes #161.

# Context/Motivation
Duc's performance naturally gets slower as the number of dirents in a filesystem increases. If the filesystem consists of an `n` node hierarchy, then the topological sort will take `O(n)` time. Each element has to be independently processed. For very large filesystems, Duc can take a long time to finish indexing. However, if Duc's indexing algorithm can be made concurrent with _t_ threads (_t_ being a parameter provided by a Duc user), then Duc's performance will significantly increase, as noted by users (#161).

Currently, Duc's indexing algorithm consists of a topological sort. For any given node `N`, the scanning algorithm is recursively ran on all the children. As each child terminates, it "frees", which consists of aggregating data that it has onto `N`, writing its own data to a buffer, and then freeing its resources.

The crux of parallelizing Duc's indexing algorithm then lies in implementing a concurrent topological sort that does exactly what Duc's current algorithm does, using a provided number of threads.

This motivates the concurrent indexing algorithm, which will now be described.

# Algorithm
DFS is an interesting algorithm. It creates a callstack of recursive calls to return to as it traverses a tree. If we view it from the perspective of a main thread `T`, Each element in `T`'s callstack can be worked independently on by another thread `T1`. If we can concretely represent this callstack (by making the algorithm iterative), then a worker-pool can be used to make DFS concurrrent. This was inspired by [a paper written by the Dept. of CS at the University of Texas](https://www.lrde.epita.fr/~bleton/doc/parallel-depth-first-search.pdf).

The algorithm is as follows:

- Initialize a worker pool of _t_ workers (_t_ is a user-supplied parameter).
- The initial worker is arbitrarily chosen, and the root of the tree is added to its stack. It then begins DFSing starting at the root of the tree.
- As the worker progresses its DFS, it creates a stack of nodes that it needs to return to.
- If the other workers see that they are out of work (their stacks are empty), they poll each others' stacks. If the number of elements on another worker's stack is greater than the cutoff frequency (a configured parameter), the worker _takes_ tasks off the other worker's stack.

In this way, all workers are doing work to traverse the tree.

### But how do we guarantee topological order of visiting the nodes?
This point is not so subtle and the original paper does not make mention of how to do this. However, I have constructed an algorithm that can do this:

Let us define a node `N` "processing" to mean the process whereby a worker puts `N`'s relevant children (directories under `N`) onto its DFS stack. Each node maintains a count of the number of children it possesses `num_children`, a boolean to indicate whether it is finished processing `done_processing`, as well as a count of its children which finished processing `completed_children`.

```
When a node N is being processed by a worker:
	Each child N possesses is placed onto the DFS stack and N's <num_children> is incremented.
After processing:
	The worker checks if either of two conditions are true for N:
		- If N is a leaf, then it has no dependencies in the topological sort,
		  and so it can be freed.
		- If N's <completed_children> count equals the <num_children>,
		  then this means that the children all finished processing (possible due to
                  concurrency of the algorithm). Then topological order is guaranteed, and
                  so the node can be freed.
	Otherwise:
		- N cannot yet be freed, otherwise topological order will be violated. It has children,
		  and those dependencies have not yet finished processing. Thus, the worker marks N as 
                  <done_processing>, and leaves the freeing of N as a duty to the LAST CHILD of N
                  which finishes processing.
```

This algorithm makes mention of "leaves the freeing of `N` as a duty to the last child". How does this happen? This requires additional logic when any given node is freed. Any time a node is freed, the worker frees it and then walks up the tree, ensuring topological order is maintained. The algorithm for freeing is as follows:

```
Given a node N:

LOOP: The worker frees N and keeps track of its parent.
The <completed_children> count of the node's parent is incremented (since the child was freed).
If the freed node's parent is not done processing:
	The parent obviously cannot be freed because it hasn't finished processing. And so
	the loop is broken.
Otherwise:
	 The freeing of the parent was left as a duty to the LAST CHILD to finish.
	 So the worker checks if this node is the last child. If it is, LOOP is repeated with
	 the parent being the new node. Otherwise, the loop terminates.
```

# Usage
This change adds two new command line options to `duc index`. These two options are `thread-count=VAL` (`-t`) and `cutoff-depth=VAL` (`-c`).

The `thread-count=VAL` option stipulates that the indexing algorithm use a given number of threads corresponding to workers. When this option is provided, duc will multithread the indexing algorithm and use `VAL` workers to traverse the filesystem. The default value is 1.

The `cutoff-depth=VAL` option ensures that each worker has at least `VAL` tasks before other workers start taking its tasks. In general the lower this is, the higher the concurrency. Default value is 2.

**Note:** The `cutoff-depth` 

### Example:
**Thread count (specified by -t or --thread-count):**
To test with 4 threads, do:
`./duc index /path/to/directory -t 4`
or, equivalently:
`./duc index /path/to/directory --thread-count=4`

**Cutoff depth (specified by -c or --cutoff-depth):**
To test with a cutoff depth of 3, do:
`./duc index /path/to/directory -c 3`
or, equivalently:
`./duc index /path/to/directory --cutoff-depth=3`
