### PR TITLE
add missing word "store"

### DIFF
--- a/doc/duc.1
+++ b/doc/duc.1
@@ -107,7 +107,7 @@ limit index to only files/dirs owned by uid
 limit index to only files/dirs owned by username
 .TP
 \fB\-m\fR, \fB\-\-max\-depth=VAL\fR
-limit directory names to given depth\. when this option is given duc will traverse the complete file system, but will only the first VAL levels of directories in the database to reduce the size of the index
+limit directory names to given depth\. when this option is given duc will traverse the complete file system, but will only store the first VAL levels of directories in the database to reduce the size of the index
 .TP
 \fB\-x\fR, \fB\-\-one\-file\-system\fR
 skip directories on different file systems

--- a/doc/duc.1.html
+++ b/doc/duc.1.html
@@ -271,7 +271,7 @@ are written to the index, and can later be queried by one of the other duc tools
 <dt>
 <code>-m</code>, <code>--max-depth=VAL</code>
 </dt>
-<dd>limit directory names to given depth. when this option is given duc will traverse the complete file system, but will only the first VAL levels of directories in the database to reduce the size of the index</dd>
+<dd>limit directory names to given depth. when this option is given duc will traverse the complete file system, but will only store the first VAL levels of directories in the database to reduce the size of the index</dd>
 <dt>
 <code>-x</code>, <code>--one-file-system</code>
 </dt>

--- a/doc/duc.md
+++ b/doc/duc.md
@@ -166,7 +166,7 @@ Options for command `duc index [options] PATH ...`:
     limit index to only files/dirs owned by username
 
   * `-m`, `--max-depth=VAL`:
-    limit directory names to given depth. when this option is given duc will traverse the complete file system, but will only the first VAL levels of directories in the database to reduce the size of the index
+    limit directory names to given depth. when this option is given duc will traverse the complete file system, but will only store the first VAL levels of directories in the database to reduce the size of the index
 
 
   * `-x`, `--one-file-system`:

--- a/src/duc/cmd-index.c
+++ b/src/duc/cmd-index.c
@@ -177,8 +177,8 @@ static struct ducrc_option options[] = {
 	{ &opt_uid,             "uid",              'U', DUCRC_TYPE_INT,    "limit index to only files/dirs owned by uid" },
 	{ &opt_username,        "username",         'u', DUCRC_TYPE_STRING, "limit index to only files/dirs owned by username" },
 	{ &opt_max_depth,       "max-depth",       'm', DUCRC_TYPE_INT,    "limit directory names to given depth" ,
-	  "when this option is given duc will traverse the complete file system, but will only the first VAL "
-	  "levels of directories in the database to reduce the size of the index" },
+	  "when this option is given duc will traverse the complete file system, but will only store the "
+	  "first VAL levels of directories in the database to reduce the size of the index" },
 	{ &opt_one_file_system, "one-file-system", 'x', DUCRC_TYPE_BOOL,   "skip directories on different file systems" },
 	{ &opt_progress,        "progress",        'p', DUCRC_TYPE_BOOL,   "show progress during indexing" },
 	{ &opt_dryrun,          "dry-run",          0 , DUCRC_TYPE_BOOL,   "do not update database, just crawl" },


### PR DESCRIPTION
The word "store" is missing from the help text.