### PR TITLE
Crash on tooltip hovering: snprintf buffer overflow fix

### DIFF
--- a/src/libduc-graph/graph.c
+++ b/src/libduc-graph/graph.c
@@ -208,9 +208,13 @@ static void gen_tooltip(duc_graph *g, struct duc_size *size, const char *name, d
 	char *p = g->tooltip_msg;
 	int l = sizeof(g->tooltip_msg);
 	if(name) {
-		p += snprintf(p, l, "name: %s\n", name);
+		int r = snprintf(p, l, "name: %s\n", name);
+		if(r > 0 && r < l) {
+			p += r;
+			l -= r;
+		}
 	}
-	p += snprintf(p, l, 
+	int r = snprintf(p, l, 
 			"type: %s\n"
 			"actual size: %s\n"
 			"apparent size: %s\n"

--- a/src/libduc-graph/graph.c
+++ b/src/libduc-graph/graph.c
@@ -206,15 +206,15 @@ static void gen_tooltip(duc_graph *g, struct duc_size *size, const char *name, d
 	duc_human_size(size, DUC_SIZE_TYPE_COUNT, g->bytes, siz_cnt, sizeof siz_cnt);
 	char *typ = duc_file_type_name(type);
 	char *p = g->tooltip_msg;
-	int l = sizeof(g->tooltip_msg);
+	int len = sizeof(g->tooltip_msg);
 	if(name) {
-		int r = snprintf(p, l, "name: %s\n", name);
-		if(r > 0 && r < l) {
+		int r = snprintf(p, len, "name: %s\n", name);
+		if(r > 0 && r < len) {
 			p += r;
-			l -= r;
+			len -= r;
 		}
 	}
-	int r = snprintf(p, l, 
+	int r = snprintf(p, len, 
 			"type: %s\n"
 			"actual size: %s\n"
 			"apparent size: %s\n"


### PR DESCRIPTION
The gen_tooltip function now properly tracks the remaining buffer space:
- Added bounds checking with `if(r > 0 && r < l)`
- Decrements remaining buffer size `l -= r` when advancing pointer `p`
- Prevents writing past the end of the tooltip_msg buffer

This should resolve the GUI crash when hovering over the graph.