### PR TITLE
Revert "real fix for possible CVE with negative length"

### DIFF
--- a/src/libduc/buffer.c
+++ b/src/libduc/buffer.c
@@ -47,7 +47,7 @@ void buffer_free(struct buffer *b)
 // Add item to buffer, but grow by doubling if needed
 static int buffer_put(struct buffer *b, const void *data, size_t len)
 {
-	if(b->ptr + len <= b->len) {
+	if(b->ptr + len > b->max) {
 		while(b->len + len > b->max) {
 			b->max *= 2;
 		}


### PR DESCRIPTION
This reverts commit 5e98e6e2e69e19d69b01f5abe910714411d0f878.

Fixes #355.

There's not enough context in the original commits for me to figure out the issue they were resolving, but this has introduced a buffer overflow it seems, which is resolved by reverting it.