### PR TITLE
INSTALL: move autoreconf -i before ./configure in Quickstart

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -4,13 +4,10 @@ Quickstart
 
 To build Duc with its default options, run:
 
+    $ autoreconf -i
     $ ./configure
     $ make
     $ sudo make install
-
-Generate the configure script when it is not available (cloned git repo):
-
-    $ autoreconf -i
 
 
 To get the required dependencies on Debian or Ubuntu, run:


### PR DESCRIPTION
When building from a git clone, `configure` does not exist yet.
`autoreconf -i` must be run first to generate it.
