### PR TITLE
fix: duc ui displays raw pointer value instead of human-readable size

### DIFF
--- a/src/duc/cmd-ui.c
+++ b/src/duc/cmd-ui.c
@@ -192,7 +192,7 @@ static duc_dir *do_dir(duc *duc, duc_dir *dir, int depth)
 				char siz[32];
 				duc_human_size(&e->size, st, opt_bytes, siz, sizeof siz);
 				if(cur != i) attrset(attr_size);
-				printw("%*lu", max_size_len, (size_t) siz);
+				printw("%*s", max_size_len, siz);
 
 				printw(" ");
 				char *p = e->name;


### PR DESCRIPTION
**Problem**

`duc ui` shows raw numbers like `140729715294144` for directory sizes instead of human-readable values like `45.2G`.

**Root cause**

In [src/duc/cmd-ui.c](cci:7://file:///home/gruinelli/temp/duc/src/duc/cmd-ui.c:0:0-0:0), the format string for printing the size column was `%*s` (correct — `siz` is a `char[]` filled by `duc_human_size()`). This was inadvertently changed to `%*l` in commit `f767128` ("fix printf number size spec", Nov 1 2024), then to `%*lu` in `d424b7b` ("fix printf number size spec for real"). Finally, commit `83a579e` ("cast value", Jun 2 2025) added an explicit `(size_t)` cast to silence the resulting compiler warning, cementing the bug: the stack address of the `siz` buffer was being printed as an unsigned integer instead of the buffer's string content.

**Fix**

Restore the correct format specifier and drop the erroneous cast:

```c
- printw("%*lu", max_size_len, (size_t) siz);
+ printw("%*s", max_size_len, siz);
```

**Introduced by:** `f767128` — Nov 1, 2024  
**Made explicit by:** `83a579e` — Jun 2, 2025